### PR TITLE
Add Expression.tryParse for handling erroneous input without exceptions

### DIFF
--- a/lib/src/expressions.dart
+++ b/lib/src/expressions.dart
@@ -24,6 +24,11 @@ abstract class Expression {
 
   static final ExpressionParser _parser = ExpressionParser();
 
+  static Expression tryParse(String formattedString) {
+    final result = _parser.expression.end().parse(formattedString);
+    return result.isSuccess ? result.value : null;
+  }
+
   static Expression parse(String formattedString) =>
       _parser.expression.end().parse(formattedString).value;
 }

--- a/test/expressions_test.dart
+++ b/test/expressions_test.dart
@@ -250,4 +250,14 @@ void main() {
       });
     });
   });
+
+  group('failure handling', () {
+    test('Expression.parse() throws on an invalid expression', () {
+      expect(() => Expression.parse('5 1 6'), throwsA(isA<ParserException>()));
+    });
+
+    test('Expression.tryParse() returns null on an invalid expression', () {
+      expect(Expression.tryParse('5 1 6'), null);
+    });
+  });
 }


### PR DESCRIPTION
Works like `parse` except that this function returns `null` where `parse` would throw a `ParserException`.