### PR TITLE
support rxdart 0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.2+1
+
+- Support rxdart ^0.27
+
 ## 0.2.2
 
 - `ExpressionEvaluator.async` now also handles futures 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: expressions
 description: A library to parse and evaluate simple dart and javascript like expressions.
-version: 0.2.2
+version: 0.2.2+1
 homepage: https://github.com/appsup-dart
 
 environment:
@@ -9,7 +9,7 @@ environment:
 dependencies:
   quiver: ^3.0.0
   petitparser: ^4.0.2
-  rxdart: ^0.26.0
+  rxdart: ">=0.26.0 <0.28.0"
   fake_async: ^1.2.0
   meta: ^1.3.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: expressions
 description: A library to parse and evaluate simple dart and javascript like expressions.
 version: 0.2.2+1
 homepage: https://github.com/appsup-dart
+repository: https://github.com/appsup-dart/expressions
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
configures pubspec.yaml to allow rxdart 0.27 - it seems between 0.26 and 0.27 were no breaking changes which affected the usage in this library 🤔️