### PR TITLE
upgrade petitparser to 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.3+1
+
+- upgrade petitparser to 5.0.0
+
 ## 0.2.3
 
 - upgrade rxdart dependency to 0.27.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: expressions
 description: A library to parse and evaluate simple dart and javascript like expressions.
-version: 0.2.3
+version: 0.2.3+1
 homepage: https://github.com/appsup-dart
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   quiver: ^3.0.0
-  petitparser: ^4.0.2
+  petitparser: ^5.0.0
   rxdart: ^0.27.0
   fake_async: ^1.2.0
   meta: ^1.3.0


### PR DESCRIPTION
Allows upgrades to `petitparser` 5.0.0, which enables version solving with newer versions of `xml`.

Solves problems like:

```
Because expressions >=0.2.0 depends on petitparser ^4.0.2 and xml >=5.4.0 depends on petitparser ^5.0.0, expressions >=0.2.0 is incompatible with xml >=5.4.0.
And because flutter_svg >=1.1.0 depends on xml ^6.0.1, expressions >=0.2.0 is incompatible with flutter_svg >=1.1.0.
So, because someapp depends on both flutter_svg ^1.1.0 and expressions ^0.2.3, version solving failed.
```