### PR TITLE
Fix whitespace issues around top-level expression and within function…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ expressions.iml
 
 # Directory created by dartdoc
 doc/api/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/

--- a/lib/src/expressions.dart
+++ b/lib/src/expressions.dart
@@ -24,12 +24,12 @@ abstract class Expression {
   static final ExpressionParser _parser = ExpressionParser();
 
   static Expression? tryParse(String formattedString) {
-    final result = _parser.expression.end().parse(formattedString);
+    final result = _parser.expression.trim().end().parse(formattedString);
     return result.isSuccess ? result.value : null;
   }
 
   static Expression parse(String formattedString) =>
-      _parser.expression.end().parse(formattedString).value;
+      _parser.expression.trim().end().parse(formattedString).value;
 }
 
 abstract class SimpleExpression implements Expression {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -238,11 +238,11 @@ class ExpressionParser {
       (char('[') & expression.trim() & char(']')).pick(1).cast();
 
   Parser<List<Expression>> get callArgument =>
-      (char('(') & arguments & char(')')).pick(1).cast();
+      (char('(') & arguments.trim() & char(')')).pick(1).cast();
 
   // Ternary expression: test ? consequent : alternate
   Parser<List<Expression>> get conditionArguments =>
-      (char('?').trim() & expression & char(':').trim())
+      (char('?').trim() & expression.trim() & char(':').trim())
           .pick(1)
           .seq(expression)
           .castList();

--- a/test/expressions_test.dart
+++ b/test/expressions_test.dart
@@ -297,6 +297,29 @@ void main() {
         expect(evaluator.eval(Expression.parse('x.y'), context), 1);
         expect(evaluator.eval(Expression.parse('x.z'), context), 2);
       });
+
+      test('leading and trailing whitespace around expression', () {
+        var evaluator = ExpressionEvaluator();
+
+        expect(evaluator.eval(Expression.parse(' 42'), {}), 42);
+        expect(evaluator.eval(Expression.parse('42 '), {}), 42);
+        expect(evaluator.eval(Expression.parse(' 42 '), {}), 42);
+      });
+
+      test('function with whitespace in arguments', () {
+        var evaluator = ExpressionEvaluator();
+
+        final context = {
+          'func': () => 42,
+          'func1': (a) => 42,
+          'func2': (a, b) => 42,
+        };
+
+        expect(evaluator.eval(Expression.parse('func()'), context), 42);
+        expect(evaluator.eval(Expression.parse('func( )'), context), 42);
+        expect(evaluator.eval(Expression.parse('func1( 1 )'), context), 42);
+        expect(evaluator.eval(Expression.parse('func2( 1, 2 )'), context), 42);
+      });
     });
   });
 


### PR DESCRIPTION
… call arguments. Fixes both issues in #19.