### PR TITLE
v0.3.0 (Dart 3 ; petitparser: ^6.0.1) 

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,65 @@
+name: Dart CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
+      - name: Dart version
+        run: |
+          dart --version
+          uname -a
+      - name: Install dependencies
+        run: dart pub get
+      - name: Upgrade dependencies
+        run: dart pub upgrade
+      - name: dart format
+        run: dart format -o none --set-exit-if-changed .
+      - name: dart analyze
+        run: dart analyze --fatal-infos --fatal-warnings .
+      - name: dependency_validator
+        run: dart run dependency_validator
+      - name: dart pub publish --dry-run
+        run: dart pub publish --dry-run
+
+
+  test_vm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
+      - name: Dart version
+        run: |
+          dart --version
+          uname -a
+      - name: Install dependencies
+        run: dart pub get
+      - name: Upgrade dependencies
+        run: dart pub upgrade
+      - name: Run tests (VM)
+        run: dart test --platform vm
+
+
+  test_chrome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
+      - name: Dart version
+        run: |
+          dart --version
+          uname -a
+      - name: Install dependencies
+        run: dart pub get
+      - name: Upgrade dependencies
+        run: dart pub upgrade
+      - name: Run tests (Chrome)
+        run: dart test --platform chrome
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 0.3.0
+
+- Migrated to `petitparser: ^6.0.1`.
+- Fixed lints.
+
+- Added GitHub Workflow `Dart CI`, with test jobs for `vm` and `chrome`. 
+
+- Updated Dart SDK constraint due to dependencies that require it.:
+  - sdk: '>=3.0.0 <4.0.0'
+
+- Updated dependencies:
+  - quiver: ^3.2.1
+  - petitparser: ^6.0.1
+  - rxdart: ^0.27.7
+  - fake_async: ^1.3.1 (only used in tests: moved to `dev_dependencies`)
+  - meta: ^1.10.0
+  - test: ^1.24.6
+  - lints: ^2.1.1
+    - `pedantic` was discontinued and replaced by `lints`.
+  - dependency_validator: ^3.2.2
+
 ## 0.2.5
 
  - **FIX**: parsing string with \\. ([7ec99cbd](https://github.com/appsup-dart/expressions/commit/7ec99cbd1ac005cd0150d224ca13fd4ea9fafd8a))

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,5 @@
-# Defines a default set of lint rules enforced for
-# projects at Google. For details and rationale,
-# see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
+include: package:lints/recommended.yaml
 
 
 analyzer:

--- a/lib/src/evaluator.dart
+++ b/lib/src/evaluator.dart
@@ -141,7 +141,8 @@ class ExpressionEvaluator {
   dynamic evalBinaryExpression(
       BinaryExpression expression, Map<String, dynamic> context) {
     var left = eval(expression.left, context);
-    var right = () => eval(expression.right, context);
+    right() => eval(expression.right, context);
+
     switch (expression.operator) {
       case '||':
         return left || right();

--- a/lib/src/expressions.dart
+++ b/lib/src/expressions.dart
@@ -25,7 +25,7 @@ abstract class Expression {
 
   static Expression? tryParse(String formattedString) {
     final result = _parser.expression.trim().end().parse(formattedString);
-    return result.isSuccess ? result.value : null;
+    return result is Success ? result.value : null;
   }
 
   static Expression parse(String formattedString) =>

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -137,7 +137,9 @@ class ExpressionParser {
       .trim();
 
   Parser<Expression> get binaryExpression =>
-      token.separatedBy(binaryOperation).map((l) {
+      token.plusSeparated(binaryOperation).map((sl) {
+        var l = sl.sequential.toList();
+
         var first = l[0];
         var stack = <dynamic>[first];
 
@@ -187,15 +189,15 @@ class ExpressionParser {
   // until the terminator character `)` or `]` is encountered.
   // e.g. `foo(bar, baz)`, `my_func()`, or `[bar, baz]`
   Parser<List<Expression>> get arguments => expression
-      .separatedBy(char(',').trim(), includeSeparators: false)
-      .castList<Expression>()
+      .plusSeparated(char(',').trim())
+      .map((sl) => sl.elements)
       .optionalWith([]);
 
   Parser<Map<Expression, Expression>> get mapArguments =>
       (expression & char(':').trim() & expression)
           .map((l) => MapEntry<Expression, Expression>(l[0], l[2]))
-          .separatedBy(char(',').trim(), includeSeparators: false)
-          .castList<MapEntry<Expression, Expression>>()
+          .plusSeparated(char(',').trim())
+          .map((sl) => sl.elements)
           .map((l) => Map.fromEntries(l))
           .optionalWith({});
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: expressions
 description: A library to parse and evaluate simple dart and javascript like expressions.
-version: 0.2.5
+version: 0.3.0
 homepage: https://github.com/appsup-dart
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  quiver: ^3.0.0
-  petitparser: ^5.0.0
-  rxdart: ^0.27.0
-  fake_async: ^1.2.0
-  meta: ^1.3.0
-
+  quiver: ^3.2.1
+  petitparser: ^6.0.1
+  rxdart: ^0.27.7
+  meta: ^1.10.0
 
 dev_dependencies:
-  test: ^1.0.0
-  pedantic: ^1.11.0
+  test: ^1.24.6
+  lints: ^2.1.1
+  dependency_validator: ^3.2.2
+  fake_async: ^1.3.1

--- a/test/async_evaluator_test.dart
+++ b/test/async_evaluator_test.dart
@@ -43,7 +43,7 @@ void main() {
           'y': controllerY.stream,
         });
 
-        var current;
+        bool? current;
         var done = false;
         stream.listen((v) => current = v, onDone: () => done = true);
 
@@ -81,7 +81,7 @@ void main() {
           'y': 20,
         });
 
-        var current;
+        Object? current;
         stream.listen((v) => current = v);
 
         async.flushMicrotasks();
@@ -148,7 +148,7 @@ void main() {
           'f': (a, b, c) => a + b + c,
         });
 
-        var current;
+        int? current;
         var done = false;
         stream.listen((v) => current = v, onDone: () => done = true);
 
@@ -197,7 +197,7 @@ void main() {
           'f': (x) => x == 'y' ? controllerY.stream : controllerZ.stream,
         });
 
-        var current;
+        int? current;
         var done = false;
         stream.listen((v) => current = v, onDone: () => done = true);
 
@@ -255,7 +255,7 @@ void main() {
           'z': controllerZ.stream,
         });
 
-        var current;
+        int? current;
         var done = false;
         stream.listen((v) => current = v, onDone: () => done = true);
 
@@ -299,7 +299,7 @@ void main() {
           'y': controllerY.stream,
         });
 
-        var current;
+        int? current;
         var done = false;
         stream.listen((v) => current = v, onDone: () => done = true);
 

--- a/test/expressions_test.dart
+++ b/test/expressions_test.dart
@@ -14,14 +14,14 @@ void main() {
       }
 
       for (var v in ['1', '-qdf', '.sfd']) {
-        expect(parser.identifier.end().parse(v).isSuccess, isFalse);
+        expect(parser.identifier.end().parse(v) is Success, isFalse);
       }
     });
 
     test('numeric literal', () {
       for (var v in ['134', '.5', '43.2', '1e3', '1E-3', '1e+0', '0x01']) {
         var w = parser.numericLiteral.end().parse(v);
-        expect(w.isSuccess, isTrue, reason: 'Failed parsing `$v`');
+        expect(w is Success, isTrue, reason: 'Failed parsing `$v`');
         expect(w.value.value, num.parse(v));
         expect(w.value.raw, v);
       }
@@ -31,7 +31,7 @@ void main() {
         '.5.4',
         '1e5E3',
       ]) {
-        expect(parser.numericLiteral.end().parse(v).isSuccess, isFalse);
+        expect(parser.numericLiteral.end().parse(v) is Success, isFalse);
       }
     });
 
@@ -46,7 +46,7 @@ void main() {
         r'"\\"',
       ]) {
         var w = parser.stringLiteral.end().parse(v);
-        expect(w.isSuccess, isTrue, reason: 'Failed parsing `$v`');
+        expect(w is Success, isTrue, reason: 'Failed parsing `$v`');
         expect(w.value.value, parser.unescape(v.substring(1, v.length - 1)));
         expect(w.value.raw, v);
       }
@@ -55,39 +55,39 @@ void main() {
         "sd'<sdf'",
         "'df'sdf'",
       ]) {
-        expect(parser.stringLiteral.end().parse(v).isSuccess, isFalse);
+        expect(parser.stringLiteral.end().parse(v) is Success, isFalse);
       }
     });
     test('bool literal', () {
       for (var v in <String>['true', 'false']) {
         var w = parser.boolLiteral.end().parse(v);
-        expect(w.isSuccess, isTrue, reason: 'Failed parsing `$v`');
+        expect(w is Success, isTrue, reason: 'Failed parsing `$v`');
         expect(w.value.value, v == 'true');
         expect(w.value.raw, v);
       }
 
       for (var v in ['True', 'False']) {
-        expect(parser.boolLiteral.end().parse(v).isSuccess, isFalse);
+        expect(parser.boolLiteral.end().parse(v) is Success, isFalse);
       }
     });
 
     test('null literal', () {
       for (var v in <String>['null']) {
         var w = parser.nullLiteral.end().parse(v);
-        expect(w.isSuccess, isTrue, reason: 'Failed parsing `$v`');
+        expect(w is Success, isTrue, reason: 'Failed parsing `$v`');
         expect(w.value.value, isNull);
         expect(w.value.raw, v);
       }
 
       for (var v in ['NULL']) {
-        expect(parser.nullLiteral.end().parse(v).isSuccess, isFalse);
+        expect(parser.nullLiteral.end().parse(v) is Success, isFalse);
       }
     });
 
     test('this literal', () {
       for (var v in <String>['this']) {
         var w = parser.thisExpression.end().parse(v);
-        expect(w.isSuccess, isTrue, reason: 'Failed parsing `$v`');
+        expect(w is Success, isTrue, reason: 'Failed parsing `$v`');
         expect(w.value, isA<ThisExpression>());
       }
     });
@@ -102,7 +102,7 @@ void main() {
       }.entries) {
         var v = e.key;
         var w = parser.mapLiteral.end().parse(v);
-        expect(w.isSuccess, isTrue, reason: 'Failed parsing `$v`');
+        expect(w is Success, isTrue, reason: 'Failed parsing `$v`');
         expect(w.value.value, e.value);
         expect(w.value.raw, v);
       }
@@ -115,13 +115,13 @@ void main() {
       }.entries) {
         var v = e.key;
         var w = parser.arrayLiteral.end().parse(v);
-        expect(w.isSuccess, isTrue, reason: 'Failed parsing `$v`');
+        expect(w is Success, isTrue, reason: 'Failed parsing `$v`');
         expect(w.value.value, e.value);
         expect(w.value.raw, v);
       }
 
       for (var v in ['[1,2[']) {
-        expect(parser.arrayLiteral.end().parse(v).isSuccess, isFalse);
+        expect(parser.arrayLiteral.end().parse(v) is Success, isFalse);
       }
     });
 
@@ -140,7 +140,7 @@ void main() {
         '(a%2)'
       ]) {
         var w = parser.token.end().parse(v);
-        expect(w.isSuccess, isTrue, reason: 'Failed parsing `$v`');
+        expect(w is Success, isTrue, reason: 'Failed parsing `$v`');
         expect(w.value.toTokenString(), v);
       }
     });
@@ -154,7 +154,7 @@ void main() {
         '1+4-5%2*5<4==(2+1)*1<=2&&2||2'
       ]) {
         var w = parser.binaryExpression.end().parse(v);
-        expect(w.isSuccess, isTrue, reason: 'Failed parsing `$v`');
+        expect(w is Success, isTrue, reason: 'Failed parsing `$v`');
         expect(w.value.toString(), v);
       }
     });
@@ -162,7 +162,7 @@ void main() {
     test('unary expression', () {
       for (var v in <String>['+1', '-a', '!true', '~0x01']) {
         var w = parser.unaryExpression.end().parse(v);
-        expect(w.isSuccess, isTrue, reason: 'Failed parsing `$v`');
+        expect(w is Success, isTrue, reason: 'Failed parsing `$v`');
         expect(w.value.toString(), v);
       }
     });
@@ -170,7 +170,7 @@ void main() {
     test('conditional expression', () {
       for (var v in <String>["1<2 ? 'always' : 'never'"]) {
         var w = parser.expression.end().parse(v);
-        expect(w.isSuccess, isTrue, reason: 'Failed parsing `$v`');
+        expect(w is Success, isTrue, reason: 'Failed parsing `$v`');
         expect(w.value.toString(), v);
       }
     });


### PR DESCRIPTION

- Migrated to `petitparser: ^6.0.1`.
- Fixed lints.

- Added GitHub Workflow `Dart CI`, with test jobs for `vm` and `chrome`. 

- Updated Dart SDK constraint due to dependencies that require it.:
  - sdk: '>=3.0.0 <4.0.0'

- Updated dependencies:
  - quiver: ^3.2.1
  - petitparser: ^6.0.1
  - rxdart: ^0.27.7
  - fake_async: ^1.3.1 (only used in tests: moved to `dev_dependencies`)
  - meta: ^1.10.0
  - test: ^1.24.6
  - lints: ^2.1.1
    - `pedantic` was discontinued and replaced by `lints`.
  - dependency_validator: ^3.2.2
