### PR TITLE
Feat: Allow member access on literal expressions such as `[1,2,3].length`

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -9,7 +9,7 @@ class ExpressionParser {
         (l) => l[1] == null
             ? l[0]
             : ConditionalExpression(l[0], l[1][0], l[1][1])));
-    token.set((literal | unaryExpression | variable).cast<Expression>());
+    token.set((unaryExpression | variable).cast<Expression>());
   }
 
   // Gobbles only identifiers
@@ -98,6 +98,10 @@ class ExpressionParser {
           arrayLiteral |
           mapLiteral)
       .cast();
+
+  Parser<Expression> get _primary =>
+      (literal | group | thisExpression | identifier.map((v) => Variable(v)))
+          .cast();
 
   // An individual part of a binary expression:
   // e.g. `foo.bar(baz)`, `1`, `'abc'`, `(a % 2)` (because it's in parenthesis)
@@ -207,9 +211,8 @@ class ExpressionParser {
   // e.g. `foo`, `bar.baz`, `foo['bar'].baz`
   // It also gobbles function calls:
   // e.g. `Math.acos(obj.angle)`
-  Parser<Expression> get variable => groupOrIdentifier
-          .seq((memberArgument.cast() | indexArgument | callArgument).star())
-          .map((l) {
+  Parser<Expression> get variable =>
+      _primary.seq((memberArgument.cast() | indexArgument | callArgument).star()).map((l) {
         var a = l[0] as Expression;
         var b = l[1] as List;
         return b.fold(a, (Expression object, argument) {
@@ -233,9 +236,6 @@ class ExpressionParser {
   // then the expression probably doesn't have a `)`
   Parser<Expression> get group =>
       (char('(') & expression.trim() & char(')')).pick(1).cast();
-
-  Parser<Expression> get groupOrIdentifier =>
-      (group | thisExpression | identifier.map((v) => Variable(v))).cast();
 
   Parser<Identifier> get memberArgument =>
       (char('.') & identifier).pick(1).cast();

--- a/test/expressions_test.dart
+++ b/test/expressions_test.dart
@@ -254,6 +254,15 @@ void main() {
     });
 
     group('member expressions', () {
+      test('literal members', () {
+        var evaluator = ExpressionEvaluator(memberAccessors: [
+          MemberAccessor<List>({'length': (v) => v.length}),
+          MemberAccessor<String>({'length': (v) => v.length})
+        ]);
+        expect(evaluator.eval(Expression.parse('[1,2,3].length'), {}), 3);
+        expect(evaluator.eval(Expression.parse("'hello'.length"), {}), 5);
+      });
+
       test('toString member', () {
         var evaluator = ExpressionEvaluator(memberAccessors: [
           MemberAccessor<Object?>({'toString': (v) => v.toString})


### PR DESCRIPTION
This pull request enhances the expression parser to support member access directly on literal expressions. This change makes the expression syntax more intuitive and aligns it with common patterns found in other programming languages.

### The problem

Previously, the parser grammar could not handle expressions like `'hello'.length` or `[1, 2, 3].length`. The parser treated literals and member-accessible expressions (like variables or grouped expressions) as mutually exclusive starting points. This forced the unnatural workaround of wrapping literals in parentheses, such as `([1, 2, 3]).length`, just to make the expression parsable.

### The Solution

The parser grammar in `lib/src/parser.dart` has been refactored to resolve this limitation:

1. A new private parser rule, _primary, has been introduced. This rule unifies several types of expressions—literal, group, this Expression, and identifier — that can serve as the base of a member or index access chain.
2. The variable parser, which is responsible for handling these access chains, was updated to use _primary as its starting point.
3. The top-level token parser was simplified to delegate literal parsing to the variable rule, which elegantly resolves the ambiguity and allows literals to be followed by member access.

These changes make the grammar more flexible while correctly handling the new syntax.

### Testing

A new test group, 'literal members', has been added to `test/expressions_test.dart`. It includes tests that specifically verify the new capability by accessing the `.length` property on list and string literals, confirming that the changes work as expected. This test would fail without the changes made. All other tests are unaffected and work just fine.

Fixes https://github.com/appsup-dart/expressions/issues/37.