### PR TITLE
Feat: Implement Lambda Functions and Callable Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [:heart: sponsor](https://github.com/sponsors/rbellens)
 
 
@@ -19,45 +18,82 @@ It is partly inspired by [jsep](http://jsep.from.so/).
 
 Example 1: evaluate expression with default evaluator
 
-    // Parse expression:
-    Expression expression = Expression.parse("cos(x)*cos(x)+sin(x)*sin(x)==1");
+```dart
+// Parse expression:
+Expression expression = Expression.parse("cos(x)*cos(x)+sin(x)*sin(x)==1");
 
-    // Create context containing all the variables and functions used in the expression
-    var context = {
-      "x": pi / 5,
-      "cos": cos,
-      "sin": sin
-    };
+// Create context containing all the variables and functions used in the expression
+var context = {
+  "x": pi / 5,
+  "cos": cos,
+  "sin": sin
+};
 
-    // Evaluate expression
-    final evaluator = const ExpressionEvaluator();
-    var r = evaluator.eval(expression, context);
+// Evaluate expression
+final evaluator = const ExpressionEvaluator();
+var r = evaluator.eval(expression, context);
 
 
-    print(r); // = true
-
+print(r); // = true
+```
 
 
 Example 2: evaluate expression with custom evaluator
 
-    // Parse expression:
-    Expression expression = Expression.parse("'Hello '+person.name");
+```dart
+// Parse expression:
+Expression expression = Expression.parse("'Hello '+person.name");
 
-    // Create context containing all the variables and functions used in the expression
-    var context = {
-      "person": new Person("Jane")
-    };
+// Create context containing all the variables and functions used in the expression
+var context = {
+  "person": new Person("Jane")
+};
 
-    // The default evaluator can not handle member expressions like `person.name`.
-    // When you want to use these kind of expressions, you'll need to create a
-    // custom evaluator that implements the `evalMemberExpression` to get property
-    // values of an object (e.g. with `dart:mirrors` or some other strategy).
-    final evaluator = const MyEvaluator();
-    var r = evaluator.eval(expression, context);
+// The default evaluator can not handle member expressions like `person.name`.
+// When you want to use these kind of expressions, you'll need to create a
+// custom evaluator that implements the `evalMemberExpression` to get property
+// values of an object (e.g. with `dart:mirrors` or some other strategy).
+final evaluator = const MyEvaluator();
+var r = evaluator.eval(expression, context);
 
 
-    print(r); // = 'Hello Jane'
+print(r); // = 'Hello Jane'
+```
 
+
+Example 3: evaluate expression with lambdas
+
+```dart
+// Expressions can also include lambdas. These are handled by creating a
+// `MemberAccessor` that returns a `Callable` object.
+
+class WhereCallable extends Callable {
+  final List<dynamic> list;
+  WhereCallable(this.list);
+
+  @override
+  dynamic call(ExpressionEvaluator evaluator, List<dynamic> args) {
+    var predicate = args[0] as Callable;
+    return list.where((e) => predicate.call(evaluator, [e]) as bool).toList();
+  }
+}
+
+// Parse expression with a lambda:
+var expression = Expression.parse('[1,9,2,5,3,2].where((e) => e > 2)');
+
+// Create an evaluator with a member accessor for `List.where`.
+// The accessor for 'where' returns our custom `WhereCallable` object.
+final evaluator = ExpressionEvaluator(memberAccessors: [
+  MemberAccessor<List>({
+    'where': (list) => WhereCallable(list as List),
+  }),
+]);
+
+// Evaluate expression:
+var r = evaluator.eval(expression, {});
+
+print(r); // = [9, 5, 3]
+```
 
 
 ## Features and bugs

--- a/lib/src/expressions.dart
+++ b/lib/src/expressions.dart
@@ -102,6 +102,16 @@ class CallExpression extends SimpleExpression {
   String toString() => '${callee.toTokenString()}(${arguments.join(', ')})';
 }
 
+class LambdaExpression extends SimpleExpression {
+  final List<Identifier> params;
+  final Expression body;
+
+  LambdaExpression(this.params, this.body);
+
+  @override
+  String toString() => '(${params.join(', ')}) => $body';
+}
+
 class UnaryExpression extends SimpleExpression {
   final String operator;
 

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -100,7 +100,11 @@ class ExpressionParser {
       .cast();
 
   Parser<Expression> get _primary =>
-      (literal | group | thisExpression | identifier.map((v) => Variable(v)))
+      (literal |
+              lambdaExpression |
+              group |
+              thisExpression |
+              identifier.map((v) => Variable(v)))
           .cast();
 
   // An individual part of a binary expression:
@@ -206,6 +210,22 @@ class ExpressionParser {
           .castList<MapEntry<Expression, Expression>>()
           .map((l) => Map.fromEntries(l))
           .optionalWith({});
+
+  Parser<List<Identifier>> get lambdaParameters =>
+      (char('(').trim() &
+              identifier
+                  .plusSeparated(char(','.trim()))
+                  .map((p) => p.elements)
+                  .castList<Identifier>()
+                  .optionalWith([]) &
+              char(')').trim())
+          .pick(1)
+          .cast<List<Identifier>>();
+
+  Parser<LambdaExpression> get lambdaExpression =>
+      (lambdaParameters.trim().seq(string('=>').trim()).seq(expression))
+          .map((l) =>
+              LambdaExpression(l[0] as List<Identifier>, l[2] as Expression));
 
   // Gobble a non-literal variable name. This variable name may include properties
   // e.g. `foo`, `bar.baz`, `foo['bar'].baz`

--- a/test/expressions_test.dart
+++ b/test/expressions_test.dart
@@ -332,6 +332,27 @@ void main() {
         expect(evaluator.eval(Expression.parse('func1( 1 )'), context), 42);
         expect(evaluator.eval(Expression.parse('func2( 1, 2 )'), context), 42);
       });
+
+      test('callable functions', () {
+        var evaluator = ExpressionEvaluator();
+        var context = {
+          'sum': SumCallable(),
+        };
+        var expression = Expression.parse('sum(1, 2, 3, 4)');
+        var result = evaluator.eval(expression, context);
+        expect(result, 10);
+      });
+
+      test('lambda functions', () {
+        var evaluator = ExpressionEvaluator(memberAccessors: [
+          MemberAccessor<List>({
+            'where': (list) => WhereCallable(list),
+          }),
+        ]);
+        var expression = Expression.parse('[1,9,2,5,3,2].where((e) => e > 2)');
+        var result = evaluator.eval(expression, {});
+        expect(result, [9, 5, 3]);
+      });
     });
   });
 
@@ -344,4 +365,42 @@ void main() {
       expect(Expression.tryParse('5 1 6'), null);
     });
   });
+}
+
+class SumCallable extends Callable {
+  @override
+  dynamic call(ExpressionEvaluator evaluator, List args) {
+    return args.cast<num>().fold<num>(0, (p, e) => p + e);
+  }
+}
+
+class WhereCallable extends Callable {
+  final List<dynamic> list;
+
+  const WhereCallable(this.list);
+
+  @override
+  dynamic call(ExpressionEvaluator evaluator, List<dynamic> args) {
+    if (args.length != 1) {
+      throw ArgumentError('where() expects one argument, got ${args.length}');
+    }
+    final predicate = args[0];
+    if (predicate is! Callable) {
+      throw ArgumentError(
+          'Argument to where() must be a function, got ${predicate.runtimeType}');
+    }
+
+    final result = <dynamic>[];
+    for (final element in list) {
+      final predicateResult = predicate.call(evaluator, [element]);
+      if (predicateResult is! bool) {
+        throw ArgumentError(
+            'Predicate must return a boolean value, but got ${predicateResult.runtimeType}');
+      }
+      if (predicateResult) {
+        result.add(element);
+      }
+    }
+    return result;
+  }
 }


### PR DESCRIPTION
This pull request introduces support for lambda functions and the underlying Callable interface that makes them possible. It closes https://github.com/appsup-dart/expressions/issues/38. Regular functions are still fully supported, no change there.

**This pull request's code should only be checked once https://github.com/appsup-dart/expressions/pull/36 is merged, as both of them modify the `lib/src/parser.dart` and this pull request is already built on the changes introduced by https://github.com/appsup-dart/expressions/pull/36. So looking at the code before the other pull request is merged will also show changes from the other pull request.**

### The Callable Interface

A new abstract class, `Callable`, has been introduced to act as a formal contract for function-like objects. When evaluating a call expression, the evaluator now checks if the callee is a `Callable`.

This is a worthwhile addition in its own right, as it allows users to implement custom functions that can validate their arguments and throw descriptive exceptions for parameter mismatches, which was not possible with the previous `Function.apply` approach.

### Lambda Functions

This PR adds parser support for lambda functions using the common arrow syntax: `(p1, p2) => body_expression`.
Evaluating a lambda expression now creates an internal `Callable` object that captures its defining context (lexical scope). This simple enhancement unlocks powerful new capabilities, allowing for expressive collection-based operations directly in the expression language.

- Filtering: `[1, 9, 2, 5, 3, 2].where((e) => e > 2)`
- Mapping: `[1, 2, 3].map((e) => e * 2)`

While the lambda receives its own arguments, it also retains access to the context in which it was created, allowing for complex expressions that mix local parameters with external variables.

The `README.md` and tests have been updated to reflect these powerful new features. We also put the example code of the `README.md` into appropriate code blocks to enable syntax highlighting on Github.

This pull request solves https://github.com/appsup-dart/expressions/issues/38