### PR TITLE
Update petitparser version constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   quiver: ^3.0.0
-  petitparser: ">=5.0.0 <7.0.0"
+  petitparser: '>=5.0.0 <8.0.0'
   rxdart: '>=0.27.0 <0.29.0'
   meta: ^1.3.0
 


### PR DESCRIPTION
This PR updates the `petitparser` version constraint to allow compatibility with newer releases and other popular packages such as [xml](https://pub.dev/packages/xml), which now depend on `petitparser` ^7.0.0.

I have verified the change by:
- Running the full test suite with `petitparser` **7.0.0** — all tests passed.
- Manually using the package in a project with `petitparser` 7.0.0 — no issues observed.

This update should make the package more flexible for users while maintaining backwards compatibility with existing `petitparser` 5.x and 6.x versions.
