### PR TITLE
Fix/numeric literal parser

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -23,11 +23,8 @@ class ExpressionParser {
   Parser<Literal> get numericLiteral =>
       ((char('0') & anyOf('xX') & (digit() | anyOf('abcdefABCDEF')).plus()) |
               (digit() | char('.')).and() &
-                  (digit().star() &
-                      ((char('.') & digit().plus()) |
-                              (anyOf('Ee') &
-                                  anyOf('+-').optional() &
-                                  digit().plus()))
+                  ((digit().star() & (char('.') & digit().plus()).optional()) &
+                      (anyOf('Ee') & anyOf('+-').optional() & digit().plus())
                           .optional()))
           .flatten()
           .map((v) {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -19,15 +19,16 @@ class ExpressionParser {
           .flatten()
           .map((v) => Identifier(v));
 
-  // Parse simple numeric literals: `12`, `3.4`, `.5`.
-  Parser<Literal> get numericLiteral => ((digit() | char('.')).and() &
-              (digit().star() &
-                  ((char('.') & digit().plus()) |
-                          (char('x') & digit().plus()) |
-                          (anyOf('Ee') &
-                              anyOf('+-').optional() &
-                              digit().plus()))
-                      .optional()))
+  // Parse simple numeric literals: `12`, `3.4`, `.5`, `0xAB`.
+  Parser<Literal> get numericLiteral =>
+      ((char('0') & anyOf('xX') & (digit() | anyOf('abcdefABCDEF')).plus()) |
+              (digit() | char('.')).and() &
+                  (digit().star() &
+                      ((char('.') & digit().plus()) |
+                              (anyOf('Ee') &
+                                  anyOf('+-').optional() &
+                                  digit().plus()))
+                          .optional()))
           .flatten()
           .map((v) {
         return Literal(num.parse(v), v);

--- a/test/expressions_test.dart
+++ b/test/expressions_test.dart
@@ -19,18 +19,24 @@ void main() {
     });
 
     test('numeric literal', () {
-      for (var v in ['134', '.5', '43.2', '1e3', '1E-3', '1e+0', '0x01']) {
+      for (var v in [
+        '134',
+        '.5',
+        '43.2',
+        '1e3',
+        '1E-3',
+        '1e+0',
+        '0x01',
+        '0xD3',
+        '0X1b'
+      ]) {
         var w = parser.numericLiteral.end().parse(v);
         expect(w is Success, isTrue, reason: 'Failed parsing `$v`');
         expect(w.value.value, num.parse(v));
         expect(w.value.raw, v);
       }
 
-      for (var v in [
-        '-134',
-        '.5.4',
-        '1e5E3',
-      ]) {
+      for (var v in ['-134', '.5.4', '1e5E3', '12x34']) {
         expect(parser.numericLiteral.end().parse(v) is Success, isFalse);
       }
     });

--- a/test/expressions_test.dart
+++ b/test/expressions_test.dart
@@ -26,6 +26,9 @@ void main() {
         '1e3',
         '1E-3',
         '1e+0',
+        '.1e2',
+        '1.23e4',
+        '.6e-7',
         '0x01',
         '0xD3',
         '0X1b'
@@ -36,8 +39,9 @@ void main() {
         expect(w.value.raw, v);
       }
 
-      for (var v in ['-134', '.5.4', '1e5E3', '12x34']) {
-        expect(parser.numericLiteral.end().parse(v) is Success, isFalse);
+      for (var v in ['-134', '.5.4', '1e5E3', '5.', '12x34']) {
+        expect(parser.numericLiteral.end().parse(v) is Success, isFalse,
+            reason: 'Expected to fail parsing `$v`');
       }
     });
 


### PR DESCRIPTION
This pull request improves the parsing of numeric literals in the expression parser and expands the corresponding test coverage. The main focus is on supporting a wider range of numeric formats, including hexadecimal and scientific notation.

Fixes #42 

**Parser enhancements:**

* Updated the `numericLiteral` parser in `parser.dart` to support hexadecimal numbers (e.g., `0xAB`, `0X1b`) and improved handling of scientific notation and decimal numbers.

**Test improvements:**

* Expanded the numeric literal tests in `expressions_test.dart` to include more valid cases (such as `.1e2`, `1.23e4`, `.6e-7`, `0xD3`, `0X1b`) and additional invalid cases (such as `5.`, `12x34`), ensuring the parser behaves correctly for a wider set of inputs.