### PR TITLE
fix: Reorder binary operators to fix parser error

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -117,10 +117,12 @@ class ExpressionParser {
     '!=': 6,
     '<=': 7,
     '>=': 7,
+    // must be before '<' to prevent the parser from prematurely accepting it as the shorter operator
+    '<<': 8,
+    // must be before '>' to prevent the parser from prematurely accepting it as the shorter operator
+    '>>': 8,
     '<': 7,
     '>': 7,
-    '<<': 8,
-    '>>': 8,
     '+': 9,
     '-': 9,
     '*': 10,

--- a/test/expressions_test.dart
+++ b/test/expressions_test.dart
@@ -151,7 +151,10 @@ void main() {
         '1+2',
         'a+b*2-Math.sqrt(2)',
         '-1+2',
-        '1+4-5%2*5<4==(2+1)*1<=2&&2||2'
+        '1+4-5%2*5<4==(2+1)*1<=2&&2||2',
+        '1<<10',
+        '4>>5',
+        '2^4~/3>=x??4'
       ]) {
         var w = parser.binaryExpression.end().parse(v);
         expect(w is Success, isTrue, reason: 'Failed parsing `$v`');
@@ -188,10 +191,12 @@ void main() {
         'x*x+y*y==z*z': true,
         'n ?? 1': 1,
         '5~/2': 2,
+        '4<<5<100>>1<<2': true,
       };
 
       expressions.forEach((e, r) {
-        expect(evaluator.eval(Expression.parse(e), context), r);
+        expect(evaluator.eval(Expression.parse(e), context), r,
+            reason: 'Failed evaluating `$e`');
       });
     });
     test('index expressions', () {


### PR DESCRIPTION
Fixes #34 

Parsing binary operators evaluates them in an or ("|") expression. Since the parser evaluates them in order and returns the first matching pattern, shorter patterns that are a prefix of a longer pattern and come earlier in the order prevent the longer pattern from ever being parsed.

This was the case for the binary operators "<<" and ">>" making any expression that contains one of the shift operators invalid. (first < is parsed as the "<" operator, the second < can not be parsed in that position.

The fix is fairly simple. The operators are reordered in the definition of binaryOperations to make sure "<<" is evaluated before "<".

Add some additional test cases for binary operation expressions.